### PR TITLE
chore: Add issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_issue.md
+++ b/.github/ISSUE_TEMPLATE/bug_issue.md
@@ -1,0 +1,15 @@
+---
+name: Bug & QA
+about: Template for bugs or QA-related issues
+title: "bug: (short description of the bug)"
+labels: "bug"
+assignees: "leehj322"
+---
+
+## Detailed Description
+
+- Please provide a clear and detailed explanation of the issue
+
+## Reference Materials
+
+- Attach any relevant materials such as screenshots, videos, etc.

--- a/.github/ISSUE_TEMPLATE/todo_issue.md
+++ b/.github/ISSUE_TEMPLATE/todo_issue.md
@@ -1,0 +1,20 @@
+---
+name: Todo or New Feature
+about: Template for todos or new feature ideas
+title: "feat: (description of the task)"
+labels: ""
+assignees: "leehj322"
+---
+
+## Planned Task
+
+- Briefly describe the task to be done (should be similar to the title)
+- e.g. Create a common button component
+
+## Task Details
+
+- Include specific implementation details or anything important the team should know
+
+## Checklist (Check and delete this)
+
+- [ ] Did you assign the appropriate label for this issue type?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## PR Title Example (Delete this line after writing your title)
+
+chore: Initialize project
+
+## Description of Changes
+
+- Describe what was implemented or modified in this feature
+
+## Attachments (Optional)
+
+- None


### PR DESCRIPTION
## Description of Changes

- Added GitHub issue templates for:
  - Feature ideas (todo)
  - Bug reports
- Added a pull request (PR) template with sections for title, description, and optional attachments
- These templates will help maintain consistency and improve team collaboration when creating issues or PRs
