### PR TITLE
feat(mainpage): Build prototype main page UI with state store and shared components

### DIFF
--- a/app/(pages)/(main)/_ui/HospitalPharmacyCard.tsx
+++ b/app/(pages)/(main)/_ui/HospitalPharmacyCard.tsx
@@ -1,0 +1,35 @@
+import {
+  Card,
+  CardContent,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import Link from "next/link";
+
+export default function HospitalPharmacyCard() {
+  return (
+    <li>
+      <Link href="/clinic/1">
+        <Card className="relative py-3">
+          {/* 거리 - 우측 상단 고정 */}
+          <span className="text-muted-foreground absolute top-2 right-3 text-sm">
+            1.2km
+          </span>
+
+          <CardContent className="px-4 py-0">
+            {/* 이름 */}
+            <CardTitle className="text-base">서울내과의원</CardTitle>
+
+            {/* 주소 */}
+            <CardDescription className="text-sm text-gray-500">
+              서울 강남구 테헤란로 123
+            </CardDescription>
+
+            {/* 전화번호 */}
+            <p className="mt-2 text-sm text-gray-700">02-123-4567</p>
+          </CardContent>
+        </Card>
+      </Link>
+    </li>
+  );
+}

--- a/app/(pages)/(main)/_ui/HospitalPharmacyTabs.tsx
+++ b/app/(pages)/(main)/_ui/HospitalPharmacyTabs.tsx
@@ -1,0 +1,50 @@
+import { useMainPageStore } from "@/stores/useMainPageStore";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import HospitalPharmacyCard from "./HospitalPharmacyCard";
+
+export default function HospitalPharmacyTabs() {
+  const { activeTab, setActiveTab } = useMainPageStore();
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="text-base font-semibold">
+          {activeTab === "hospital" ? "병원" : "약국"} 목록
+        </h2>
+        <span className="text-sm text-gray-500">총 0 곳 검색됨</span>
+      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) =>
+          setActiveTab(value as "hospital" | "pharmacy")
+        }
+      >
+        <TabsList className="mb-4 w-full justify-around">
+          <TabsTrigger value="hospital" className="cursor-pointer">
+            병원
+          </TabsTrigger>
+          <TabsTrigger value="pharmacy" className="cursor-pointer">
+            약국
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="hospital">
+          <ul className="space-y-3">
+            <HospitalPharmacyCard />
+            <HospitalPharmacyCard />
+            <HospitalPharmacyCard />
+            <HospitalPharmacyCard />
+            <HospitalPharmacyCard />
+          </ul>
+        </TabsContent>
+
+        <TabsContent value="pharmacy">
+          <ul className="space-y-3">
+            <HospitalPharmacyCard />
+          </ul>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/app/(pages)/(main)/_ui/NearbyFilter.tsx
+++ b/app/(pages)/(main)/_ui/NearbyFilter.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { useMainPageStore } from "@/stores/useMainPageStore";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { MapPin, Filter, Moon, Music, Gift, BookOpen } from "lucide-react";
+
+export default function NearbyFilter() {
+  const { filterGroups, setFilterGroups } = useMainPageStore();
+  const [isFilterVisible, setIsFilterVisible] = useState(false);
+
+  return (
+    <div className="space-y-4 border-b p-4">
+      {/* 내 위치 기준 버튼 + 필터 토글 버튼 */}
+      <div className="flex w-full gap-2">
+        <Button variant="secondary" className="flex-1 hover:cursor-pointer">
+          <MapPin className="mr-1" size={16} />내 주변 찾기
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-9 hover:cursor-pointer"
+          onClick={() => setIsFilterVisible((prev) => !prev)}
+        >
+          <Filter size={16} />
+        </Button>
+      </div>
+      {isFilterVisible && (
+        <>
+          {/* 거리 필터 */}
+          <div>
+            <p className="mb-1 text-sm font-medium">거리 (km)</p>
+            <Slider
+              defaultValue={[1]}
+              max={5}
+              step={0.5}
+              onValueChange={(value) => setFilterGroups("distance", value[0])}
+              className="hover:cursor-pointer"
+            />
+            <p className="mt-2 text-sm text-emerald-600">
+              {filterGroups.distance} km
+            </p>
+          </div>
+
+          {/* 영업시간 필터 */}
+          <div className="space-y-2">
+            <p className="text-sm font-medium">영업 시간</p>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setFilterGroups("night", (prev) => !prev);
+                  setFilterGroups("nightTime", 6);
+                }}
+                className={`flex items-center gap-1 hover:cursor-pointer ${
+                  filterGroups.night && "text-emerald-600"
+                }`}
+              >
+                <Moon size={16} />
+                야간 (6시 이후)
+              </Button>
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setFilterGroups("saturday", (prev) => !prev)}
+                className={`flex items-center gap-1 hover:cursor-pointer ${
+                  filterGroups.saturday && "text-emerald-600"
+                }`}
+              >
+                <Music size={16} />
+                토요일
+              </Button>
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setFilterGroups("sunday", (prev) => !prev)}
+                className={`flex items-center gap-1 hover:cursor-pointer ${
+                  filterGroups.sunday && "text-emerald-600"
+                }`}
+              >
+                <BookOpen size={16} />
+                일요일
+              </Button>
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setFilterGroups("holiday", (prev) => !prev)}
+                className={`flex items-center gap-1 hover:cursor-pointer ${
+                  filterGroups.holiday && "text-emerald-600"
+                }`}
+              >
+                <Gift size={16} />
+                공휴일
+              </Button>
+            </div>
+
+            {/* 시간대 선택 (야간 버튼이 클릭된 경우에만 활성화) */}
+            {filterGroups.night && (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium">시간대 선택</p>
+                  <p className="text-xs text-gray-400">
+                    ※ 6시 이전은 선택할 수 없습니다
+                  </p>
+                </div>
+                <Slider
+                  defaultValue={[6]}
+                  max={12}
+                  min={5}
+                  step={1}
+                  onValueChange={(value) => {
+                    setFilterGroups("nightTime", Math.max(value[0], 6)); // 6시 이후만 입력값 가능
+                  }}
+                  className="hover:cursor-pointer"
+                />
+                <p className="mt-2 text-sm text-emerald-600">
+                  {filterGroups.nightTime}시 이후
+                </p>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/(pages)/(main)/_ui/SearchBar.tsx
+++ b/app/(pages)/(main)/_ui/SearchBar.tsx
@@ -1,0 +1,17 @@
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Search } from "lucide-react";
+
+export default function SearchBar() {
+  return (
+    <div className="border-b p-4">
+      <div className="flex gap-2">
+        <Input placeholder="병원 또는 약국 이름 / 주소" className="flex-1" />
+        <Button variant="default" className="cursor-pointer">
+          <Search className="mr-1" size={16} />
+          검색
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(pages)/(main)/page.tsx
+++ b/app/(pages)/(main)/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useRef } from "react";
+import { useMainPageStore } from "@/stores/useMainPageStore";
+import ScrollToTopButton from "@/app/_ui/shared/ScrollToTopButton";
+import KakaoMap from "@/app/_ui/shared/KakaoMap";
+import SearchBar from "./_ui/SearchBar";
+import NearbyFilter from "./_ui/NearbyFilter";
+import HospitalPharmacyTabs from "./_ui/HospitalPharmacyTabs";
+
+export default function MainPage() {
+  const { activeTab, setActiveTab } = useMainPageStore();
+  const topButtonTriggerRef = useRef<HTMLDivElement | null>(null);
+
+  return (
+    <div className="flex flex-col md:h-[calc(100vh-5rem)] md:flex-row">
+      {/* Left: Kakao Map */}
+      <KakaoMap
+        markerFilter={{
+          selectedMarker: activeTab,
+          onChange: (value) => setActiveTab(value),
+        }}
+        ref={topButtonTriggerRef}
+      />
+
+      {/* Right: Sidebar (Bottom Menu on Mobile) */}
+      <div className="flex h-1/2 w-full flex-col border-l bg-white md:h-full md:w-1/3">
+        <SearchBar />
+        <NearbyFilter />
+        <HospitalPharmacyTabs />
+      </div>
+
+      <ScrollToTopButton triggerRef={topButtonTriggerRef} />
+    </div>
+  );
+}

--- a/app/(pages)/clinic/[id]/page.tsx
+++ b/app/(pages)/clinic/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function ClinicDetailPage() {
+  return <div>상세 페이지</div>;
+}

--- a/app/_ui/shared/KakaoMap.tsx
+++ b/app/_ui/shared/KakaoMap.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+
+interface KakaoMapProps {
+  markerFilter?: {
+    selectedMarker: "hospital" | "pharmacy";
+    onChange: (value: "hospital" | "pharmacy") => void;
+  };
+  ref?: React.RefObject<HTMLDivElement | null>;
+}
+
+export default function KakaoMap({ markerFilter, ref }: KakaoMapProps) {
+  return (
+    <div className="relative h-[50vh] w-full md:h-full md:w-2/3" ref={ref}>
+      {/* KakaoMap 컴포넌트로 대체 */}
+      <div className="flex h-full w-full items-center justify-center bg-gray-200">
+        <span className="text-gray-500">Kakao Map Placeholder</span>
+      </div>
+
+      {/* 지도 위 마커 타입 필터 */}
+      {markerFilter && (
+        <div className="absolute top-4 left-4 z-10 flex space-x-2 rounded-xl bg-white p-2 shadow-md">
+          <RadioGroup
+            value={markerFilter.selectedMarker}
+            onValueChange={markerFilter.onChange}
+          >
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem
+                id="hospital"
+                value="hospital"
+                className="cursor-pointer"
+              />
+              <Label htmlFor="hospital" className="cursor-pointer text-sm">
+                병원
+              </Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <RadioGroupItem
+                id="pharmacy"
+                value="pharmacy"
+                className="cursor-pointer"
+              />
+              <Label htmlFor="pharmacy" className="cursor-pointer text-sm">
+                약국
+              </Label>
+            </div>
+          </RadioGroup>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/_ui/shared/ScrollToTopButton.tsx
+++ b/app/_ui/shared/ScrollToTopButton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
+
+interface ScrollToTopButtonProps {
+  triggerRef: React.RefObject<HTMLElement | null>;
+}
+
+export default function ScrollToTopButton({
+  triggerRef,
+}: ScrollToTopButtonProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!triggerRef.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setVisible(!entry.isIntersecting);
+      },
+      { root: null, threshold: 0 },
+    );
+
+    observer.observe(triggerRef.current);
+
+    return () => {
+      if (triggerRef.current) observer.unobserve(triggerRef.current);
+    };
+  }, [triggerRef]);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className="fixed right-6 bottom-6 z-50 cursor-pointer rounded-full border border-emerald-600 bg-white p-3 text-emerald-600 shadow-lg transition-colors hover:bg-gray-100"
+      aria-label="맨 위로 이동"
+    >
+      <ArrowUp className="h-5 w-5" />
+    </button>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,0 @@
-export default function Home() {
-  return (
-    <div className="p-20 text-4xl font-bold text-gray-900">건강 나침반</div>
-  );
-}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { CircleIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  )
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.6",
+    "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-radio-group": "^1.2.3",
+    "@radix-ui/react-slider": "^1.2.3",
+    "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-tabs": "^1.1.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.483.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,21 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.6
         version: 2.1.6(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-label':
+        specifier: ^2.1.2
+        version: 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slider':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.3
+        version: 1.1.3(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -336,6 +351,9 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@radix-ui/number@1.1.0':
+    resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
+
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
 
@@ -449,6 +467,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.2':
+    resolution: {integrity: sha512-zo1uGMTaNlHehDyFQcDZXRJhUPDuukcnHz0/jnrup0JA6qL+AFpAnty+7VKa9esuU5xTblAZzTGYJKSKaBxBhw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-menu@2.1.6':
     resolution: {integrity: sha512-tBBb5CXDJW3t2mo9WlO7r6GTmWV0F0uzHZVFmlRmYpiSK1CDU5IKojP1pm7oknpBOrFZx/YgBRW9oorPO2S/Lg==}
     peerDependencies:
@@ -514,8 +545,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-radio-group@1.2.3':
+    resolution: {integrity: sha512-xtCsqt8Rp09FK50ItqEqTJ7Sxanz8EM8dnkVIhJrc/wkMMomSmXHvYbhv3E7Zx4oXh98aaLt9W679SUYXg4IDA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.2':
     resolution: {integrity: sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.2.3':
+    resolution: {integrity: sha512-nNrLAWLjGESnhqBqcCNW4w2nn7LxudyMzeB6VgdyAnFLC6kfQgnAjSL2v6UkQTnDctJBlxrmxfplWS4iYjdUTw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -534,6 +591,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.3':
+    resolution: {integrity: sha512-9mFyI30cuRDImbmFF6O2KUJdgEOsGh9Vmx9x/Dh9tOhL7BngmQPQfwW4aejKm5OHpfWIdmeV6ySyuxoOGjtNng==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.0':
@@ -565,6 +635,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.0':
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.0':
+    resolution: {integrity: sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2316,6 +2395,8 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@radix-ui/number@1.1.0': {}
+
   '@radix-ui/primitive@1.1.1': {}
 
   '@radix-ui/react-arrow@1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
@@ -2409,6 +2490,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.12
 
+  '@radix-ui/react-label@2.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.12
+      '@types/react-dom': 19.0.4(@types/react@19.0.12)
+
   '@radix-ui/react-menu@2.1.6(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -2482,6 +2572,24 @@ snapshots:
       '@types/react': 19.0.12
       '@types/react-dom': 19.0.4(@types/react@19.0.12)
 
+  '@radix-ui/react-radio-group@1.2.3(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.12
+      '@types/react-dom': 19.0.4(@types/react@19.0.12)
+
   '@radix-ui/react-roving-focus@1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -2499,12 +2607,47 @@ snapshots:
       '@types/react': 19.0.12
       '@types/react-dom': 19.0.4(@types/react@19.0.12)
 
+  '@radix-ui/react-slider@1.2.3(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.0
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.12
+      '@types/react-dom': 19.0.4(@types/react@19.0.12)
+
   '@radix-ui/react-slot@1.1.2(@types/react@19.0.12)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.12)(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.12
+
+  '@radix-ui/react-tabs@1.1.3(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.12
+      '@types/react-dom': 19.0.4(@types/react@19.0.12)
 
   '@radix-ui/react-use-callback-ref@1.1.0(@types/react@19.0.12)(react@19.0.0)':
     dependencies:
@@ -2527,6 +2670,12 @@ snapshots:
       '@types/react': 19.0.12
 
   '@radix-ui/react-use-layout-effect@1.1.0(@types/react@19.0.12)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.12
+
+  '@radix-ui/react-use-previous@1.1.0(@types/react@19.0.12)(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:

--- a/stores/useMainPageStore.ts
+++ b/stores/useMainPageStore.ts
@@ -1,0 +1,52 @@
+import { create } from "zustand";
+
+interface FilterGroups {
+  distance: number;
+  nightTime: number;
+  night: boolean;
+  saturday: boolean;
+  sunday: boolean;
+  holiday: boolean;
+}
+
+interface MainPageState {
+  filterGroups: FilterGroups;
+  setFilterGroups: <K extends keyof FilterGroups>(
+    key: K,
+    value: FilterGroups[K] extends boolean
+      ? FilterGroups[K] | ((prev: FilterGroups[K]) => FilterGroups[K])
+      : FilterGroups[K],
+  ) => void;
+  activeTab: "hospital" | "pharmacy";
+  setActiveTab: (tab: "hospital" | "pharmacy") => void;
+}
+
+export const useMainPageStore = create<MainPageState>((set) => ({
+  filterGroups: {
+    distance: 1,
+    nightTime: 6,
+    night: false,
+    saturday: false,
+    sunday: false,
+    holiday: false,
+  },
+  setFilterGroups: (key, valueOrFn) =>
+    set((state) => {
+      const currentValue = state.filterGroups[key];
+      const newValue =
+        typeof valueOrFn === "function" // prev => !prev 같은 함수형 입력 처리
+          ? (valueOrFn as (prev: typeof currentValue) => typeof currentValue)(
+              currentValue,
+            ) // Fn(currentValue);
+          : valueOrFn; // value
+
+      return {
+        filterGroups: {
+          ...state.filterGroups,
+          [key]: newValue,
+        },
+      };
+    }),
+  activeTab: "hospital",
+  setActiveTab: (tab) => set({ activeTab: tab }),
+}));


### PR DESCRIPTION
## Description of Changes

- Set up Zustand-based `useMainPageStore.ts` for managing shared UI state
- Implemented the full UI layout for the `MainPage`, including:
  - SearchBar component
  - NearbyFilter component
  - Hospital/Pharmacy tabs and Card component
  - Placeholder for KakaoMap
  - ScrollToTopButton for improved UX
- Moved `page.tsx` to integrate and organize layout structure

## Attachments (Optional)
![localhost_3000_ (1)](https://github.com/user-attachments/assets/8ceccf92-a3df-432b-9f59-a8d730bf8c37)
