### PR TITLE
feat: Fetch initital nearby search data using Kakao and public API

### DIFF
--- a/app/(pages)/(main)/_ui/HospitalPharmacyCard.tsx
+++ b/app/(pages)/(main)/_ui/HospitalPharmacyCard.tsx
@@ -5,28 +5,29 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import Link from "next/link";
+import { formatDistance } from "@/utils/formatDistance";
+import { PlaceWithDetails } from "@/lib/api/getPlacesByLocation";
 
-export default function HospitalPharmacyCard() {
+interface HospitalPharmacyCardProps {
+  place: PlaceWithDetails;
+}
+
+export default function HospitalPharmacyCard({
+  place,
+}: HospitalPharmacyCardProps) {
   return (
     <li>
-      <Link href="/clinic/1">
+      <Link href={`/clinic/${place.id}`}>
         <Card className="relative py-3">
-          {/* 거리 - 우측 상단 고정 */}
           <span className="text-muted-foreground absolute top-2 right-3 text-sm">
-            1.2km
+            {formatDistance(Number(place.distance))}
           </span>
-
           <CardContent className="px-4 py-0">
-            {/* 이름 */}
-            <CardTitle className="text-base">서울내과의원</CardTitle>
-
-            {/* 주소 */}
+            <CardTitle className="text-base">{place.place_name}</CardTitle>
             <CardDescription className="text-sm text-gray-500">
-              서울 강남구 테헤란로 123
+              {place.road_address_name}
             </CardDescription>
-
-            {/* 전화번호 */}
-            <p className="mt-2 text-sm text-gray-700">02-123-4567</p>
+            <p className="mt-2 text-sm text-gray-700">{place.phone}</p>
           </CardContent>
         </Card>
       </Link>

--- a/app/(pages)/(main)/_ui/HospitalPharmacyTabs.tsx
+++ b/app/(pages)/(main)/_ui/HospitalPharmacyTabs.tsx
@@ -1,8 +1,17 @@
 import { useMainPageStore } from "@/stores/useMainPageStore";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import HospitalPharmacyCard from "./HospitalPharmacyCard";
+import { PlacesByLocationResponse } from "@/lib/api/getPlacesByLocation";
 
-export default function HospitalPharmacyTabs() {
+interface HospitalPharmacyTabsProps {
+  hospitals: PlacesByLocationResponse | undefined;
+  pharmacies: PlacesByLocationResponse | undefined;
+}
+
+export default function HospitalPharmacyTabs({
+  hospitals,
+  pharmacies,
+}: HospitalPharmacyTabsProps) {
   const { activeTab, setActiveTab } = useMainPageStore();
 
   return (
@@ -11,7 +20,15 @@ export default function HospitalPharmacyTabs() {
         <h2 className="text-base font-semibold">
           {activeTab === "hospital" ? "병원" : "약국"} 목록
         </h2>
-        <span className="text-sm text-gray-500">총 0 곳 검색됨</span>
+        <span className="text-sm text-gray-500">
+          총
+          <span className="m-1">
+            {activeTab === "hospital"
+              ? hospitals?.meta.total_count || 0
+              : pharmacies?.meta.total_count || 0}
+          </span>
+          곳 검색됨
+        </span>
       </div>
 
       <Tabs
@@ -30,21 +47,55 @@ export default function HospitalPharmacyTabs() {
         </TabsList>
 
         <TabsContent value="hospital">
-          <ul className="space-y-3">
-            <HospitalPharmacyCard />
-            <HospitalPharmacyCard />
-            <HospitalPharmacyCard />
-            <HospitalPharmacyCard />
-            <HospitalPharmacyCard />
-          </ul>
+          {hospitals == null ? (
+            <NoFilter />
+          ) : hospitals.places.length === 0 ? (
+            <NoNearbyPlaces type="hospital" />
+          ) : (
+            <ul className="space-y-3">
+              {hospitals.places.map((hospital) => (
+                <HospitalPharmacyCard key={hospital.id} place={hospital} />
+              ))}
+            </ul>
+          )}
         </TabsContent>
 
         <TabsContent value="pharmacy">
-          <ul className="space-y-3">
-            <HospitalPharmacyCard />
-          </ul>
+          {pharmacies == null ? (
+            <NoFilter />
+          ) : pharmacies.places.length === 0 ? (
+            <NoNearbyPlaces type="pharmacy" />
+          ) : (
+            <ul className="space-y-3">
+              {pharmacies.places.map((pharmacy) => (
+                <HospitalPharmacyCard key={pharmacy.id} place={pharmacy} />
+              ))}
+            </ul>
+          )}
         </TabsContent>
       </Tabs>
+    </div>
+  );
+}
+
+function NoFilter() {
+  return (
+    <div className="flex h-40 items-center justify-center text-center text-gray-500">
+      병원/약국을 검색하거나
+      <br />
+      위치 정보를 입력해주세요.
+    </div>
+  );
+}
+
+interface NoNearbyPlacesProps {
+  type: "hospital" | "pharmacy";
+}
+
+function NoNearbyPlaces({ type }: NoNearbyPlacesProps) {
+  return (
+    <div className="flex h-40 items-center justify-center text-gray-500">
+      주변에 {type === "hospital" ? "병원" : "약국"}이 없습니다.
     </div>
   );
 }

--- a/app/(pages)/(main)/page.tsx
+++ b/app/(pages)/(main)/page.tsx
@@ -1,16 +1,51 @@
 "use client";
 
-import { useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useMainPageStore } from "@/stores/useMainPageStore";
 import ScrollToTopButton from "@/app/_ui/shared/ScrollToTopButton";
 import KakaoMap from "@/app/_ui/shared/KakaoMap";
 import SearchBar from "./_ui/SearchBar";
 import NearbyFilter from "./_ui/NearbyFilter";
 import HospitalPharmacyTabs from "./_ui/HospitalPharmacyTabs";
+import { usePlacesByLocation } from "@/lib/queries/usePlaceQueries";
+
+const DEFAULT_GEOLOCATION = {
+  latitude: 37.5716486,
+  longitude: 126.97637277,
+};
 
 export default function MainPage() {
   const { activeTab, setActiveTab } = useMainPageStore();
   const topButtonTriggerRef = useRef<HTMLDivElement | null>(null);
+
+  const [geoLocation, setGeoLocation] = useState<GeolocationCoordinates | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!navigator.geolocation) {
+      console.log("이 브라우저는 위치 정보를 지원하지 않습니다.");
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      (success) => {
+        console.log("사용자가 위치 정보를 허용했습니다.");
+        if (success.coords.accuracy < 100) {
+          setGeoLocation(success.coords);
+        } else {
+          console.log("위치 정보가 정확하지 않습니다 직접 입력 해주세요.");
+        }
+      },
+      (error) => {
+        if (error.code === error.PERMISSION_DENIED) {
+          console.log("사용자가 위치 정보 제공을 거부했습니다.");
+        } else {
+          console.log("위치 정보를 가져오는 중 오류 발생:", error.message);
+        }
+      },
+    );
+  }, []);
 
   return (
     <div className="flex flex-col md:h-[calc(100vh-5rem)] md:flex-row">

--- a/app/(pages)/(main)/page.tsx
+++ b/app/(pages)/(main)/page.tsx
@@ -15,11 +15,33 @@ const DEFAULT_GEOLOCATION = {
 };
 
 export default function MainPage() {
-  const { activeTab, setActiveTab } = useMainPageStore();
+  const { filterGroups, activeTab, setActiveTab } = useMainPageStore();
   const topButtonTriggerRef = useRef<HTMLDivElement | null>(null);
 
   const [geoLocation, setGeoLocation] = useState<GeolocationCoordinates | null>(
     null,
+  );
+
+  const { data: hospitals } = usePlacesByLocation(
+    geoLocation?.latitude || DEFAULT_GEOLOCATION.latitude,
+    geoLocation?.longitude || DEFAULT_GEOLOCATION.longitude,
+    filterGroups.distance * 1000,
+    1,
+    "hospital",
+    {
+      enabled: !!geoLocation,
+    },
+  );
+
+  const { data: pharmacies } = usePlacesByLocation(
+    geoLocation?.latitude || DEFAULT_GEOLOCATION.latitude,
+    geoLocation?.longitude || DEFAULT_GEOLOCATION.longitude,
+    filterGroups.distance * 1000,
+    1,
+    "pharmacy",
+    {
+      enabled: !!geoLocation,
+    },
   );
 
   useEffect(() => {
@@ -62,7 +84,7 @@ export default function MainPage() {
       <div className="flex h-1/2 w-full flex-col border-l bg-white md:h-full md:w-1/3">
         <SearchBar />
         <NearbyFilter />
-        <HospitalPharmacyTabs />
+        <HospitalPharmacyTabs hospitals={hospitals} pharmacies={pharmacies} />
       </div>
 
       <ScrollToTopButton triggerRef={topButtonTriggerRef} />

--- a/lib/api/getPlacesByLocation.ts
+++ b/lib/api/getPlacesByLocation.ts
@@ -1,0 +1,103 @@
+import { getPlaceByCategory } from "./kakaoLocal";
+import {
+  getHospitalDetailsByName,
+  getPharmacyDetailsByName,
+} from "./publicData";
+
+export interface PlaceDocumentSummary {
+  road_address_name: string;
+  category_name: string;
+  distance: string;
+  id: string;
+  phone: string;
+  place_name: string;
+  place_url: string;
+  x: string;
+  y: string;
+}
+
+export interface PlaceWithDetails extends PlaceDocumentSummary {
+  details: Record<string, string> | null; // 공공 데이터 response가 데이터마다 전부 달라서 Record로 처리
+}
+
+export interface Meta {
+  is_end: boolean;
+  pageable_count: number;
+  same_name: any;
+  total_count: number;
+}
+
+export interface PlacesByLocationResponse {
+  places: PlaceWithDetails[];
+  meta: Meta;
+}
+
+export const getPlacesByLocation = async (
+  lat: number,
+  lng: number,
+  radius: number,
+  page: number,
+  category: "hospital" | "pharmacy",
+): Promise<PlacesByLocationResponse> => {
+  // Kakao local API 요청
+  const { documents: places, meta } = await getPlaceByCategory(
+    lat,
+    lng,
+    radius,
+    page,
+    category,
+  );
+
+  const placesSummary: PlaceDocumentSummary[] = [];
+  // place에 실제로 key, value가 더 있으나 사용하지 않기 때문에 타입 정의는 PlaceDocumentSummary로 함
+  places.forEach((place: PlaceDocumentSummary) => {
+    placesSummary.push({
+      road_address_name: place.road_address_name,
+      category_name: place.category_name,
+      distance: place.distance,
+      id: place.id,
+      phone: place.phone,
+      place_name: place.place_name,
+      place_url: place.place_url,
+      x: place.x,
+      y: place.y,
+    });
+  });
+
+  // 공공 데이터 API 요청 병렬 처리
+  const placesWithDetails = await Promise.all(
+    placesSummary.map(async (placesSummary) => {
+      const { place_name, road_address_name } = placesSummary;
+      try {
+        let details = null;
+        if (category === "hospital") {
+          details = await getHospitalDetailsByName(
+            place_name,
+            road_address_name,
+          );
+        } else {
+          details = await getPharmacyDetailsByName(
+            place_name,
+            road_address_name,
+          );
+        }
+        return {
+          ...placesSummary,
+          details,
+        };
+      } catch (error) {
+        console.error(`공공 데이터 요청 실패: ${place_name}} ${error}`);
+        return {
+          ...placesSummary,
+          details: null,
+        };
+      }
+    }),
+  );
+
+  // 두 API Response를 합쳐서 반환
+  return {
+    places: placesWithDetails,
+    meta,
+  } as PlacesByLocationResponse;
+};

--- a/lib/api/kakaoLocal.ts
+++ b/lib/api/kakaoLocal.ts
@@ -1,0 +1,38 @@
+const CATEGORY_CODE = {
+  hospital: "HP8",
+  pharmacy: "PM9",
+};
+
+export const getPlaceByCategory = async (
+  lat: number,
+  lng: number,
+  radius: number,
+  page: number,
+  category: "hospital" | "pharmacy",
+) => {
+  const categoryCode = CATEGORY_CODE[category];
+
+  const query = `category_group_code=${categoryCode}&x=${lng}&y=${lat}&radius=${radius}&size=10&page=${page}&sort=distance`;
+
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_KAKAO_LOCAL_BASE_URL}/search/category.json?${query}`,
+      {
+        headers: {
+          Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}`,
+        },
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error(`Kakao API Error ${res.status}: ${res.text()}`);
+    }
+
+    const data = await res.json();
+    return data;
+  } catch (error) {
+    throw new Error(
+      `${category === "hospital" ? "병원" : "약국"} 정보 불러오기 실패: ${(error as Error).message}`,
+    );
+  }
+};

--- a/lib/api/publicData.ts
+++ b/lib/api/publicData.ts
@@ -1,0 +1,53 @@
+import { parseStringPromise } from "xml2js";
+
+export const getHospitalDetailsByName = async (name: string, addr?: string) => {
+  // QN 파라미터에 공백 등이 포함될 수 있어 encodeURIComponent 적용
+  let query = `serviceKey=${process.env.NEXT_PUBLIC_DATA_GO_KR_API_KEY}&QN=${encodeURIComponent(name)}`;
+  if (addr) {
+    query += `&Q0=${addr.split(" ")[0]}`;
+  }
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_DATA_HOSPITAL_BASE_URL}/getHsptlMdcncListInfoInqire?${query}`,
+  );
+
+  if (!res.ok) {
+    throw new Error(
+      `공공의료 데이터 API 오류 (국립중앙의료원 병의원 정보): ${await res.text()}`,
+    );
+  }
+
+  const xmlText = await res.text();
+  const jsonData = await parseStringPromise(xmlText, {
+    explicitArray: false,
+    trim: true,
+  });
+
+  return jsonData.response?.body?.items?.item;
+};
+
+export const getPharmacyDetailsByName = async (name: string, addr?: string) => {
+  // QN 파라미터에 공백 등이 포함될 수 있어 encodeURIComponent 적용
+  let query = `serviceKey=${process.env.NEXT_PUBLIC_DATA_GO_KR_API_KEY}&QN=${encodeURIComponent(name)}`;
+  if (addr) {
+    query += `&Q0=${addr.split(" ")[0]}`;
+  }
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_DATA_PHARMACY_BASE_URL}/getParmacyListInfoInqire?${query}`,
+  );
+
+  if (!res.ok) {
+    throw new Error(
+      `공공의료 데이터 API 오류 (국립중앙의료원 약국 정보): ${await res.text()}`,
+    );
+  }
+
+  const xmlText = await res.text();
+  const jsonData = await parseStringPromise(xmlText, {
+    explicitArray: false,
+    trim: true,
+  });
+
+  return jsonData.response?.body?.items?.item;
+};

--- a/lib/queries/queryKeys.ts
+++ b/lib/queries/queryKeys.ts
@@ -1,0 +1,11 @@
+export const QUERY_KEYS = {
+  places: {
+    byLocation: (
+      lat: number,
+      lng: number,
+      radius: number,
+      page: number,
+      category: string,
+    ) => ["place", category, { lat, lng, radius, page }],
+  },
+};

--- a/lib/queries/usePlaceQueries.ts
+++ b/lib/queries/usePlaceQueries.ts
@@ -1,0 +1,22 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { QUERY_KEYS } from "./queryKeys";
+import { getPlacesByLocation } from "../api/getPlacesByLocation";
+import { PlacesByLocationResponse } from "../api/getPlacesByLocation";
+
+export const usePlacesByLocation = (
+  lat: number,
+  lng: number,
+  radius: number = 1000,
+  page: number = 1,
+  category: "hospital" | "pharmacy" = "hospital",
+  options?: Omit<
+    UseQueryOptions<PlacesByLocationResponse>,
+    "queryKey" | "queryFn"
+  >,
+) => {
+  return useQuery<PlacesByLocationResponse>({
+    queryKey: QUERY_KEYS.places.byLocation(lat, lng, radius, page, category),
+    queryFn: () => getPlacesByLocation(lat, lng, radius, page, category),
+    ...options,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.0.2",
     "tw-animate-css": "^1.2.4",
+    "xml2js": "^0.6.2",
     "zustand": "^5.0.3"
   },
   "devDependencies": {
@@ -33,6 +34,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/xml2js": "^0.4.14",
     "eslint": "^9",
     "eslint-config-next": "15.2.3",
     "prettier": "^3.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       tw-animate-css:
         specifier: ^1.2.4
         version: 1.2.4
+      xml2js:
+        specifier: ^0.6.2
+        version: 0.6.2
       zustand:
         specifier: ^5.0.3
         version: 5.0.3(@types/react@19.0.12)(react@19.0.0)
@@ -75,6 +78,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.0.4(@types/react@19.0.12)
+      '@types/xml2js':
+        specifier: ^0.4.14
+        version: 0.4.14
       eslint:
         specifier: ^9
         version: 9.22.0(jiti@2.4.2)
@@ -808,6 +814,9 @@ packages:
 
   '@types/react@19.0.12':
     resolution: {integrity: sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==}
+
+  '@types/xml2js@0.4.14':
+    resolution: {integrity: sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==}
 
   '@typescript-eslint/eslint-plugin@8.27.0':
     resolution: {integrity: sha512-4henw4zkePi5p252c8ncBLzLce52SEUz2Ebj8faDnuUXz2UuHEONYcJ+G0oaCF+bYCWVZtrGzq3FD7YXetmnSA==}
@@ -1966,6 +1975,9 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
@@ -2196,6 +2208,14 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2850,6 +2870,10 @@ snapshots:
   '@types/react@19.0.12':
     dependencies:
       csstype: 3.1.3
+
+  '@types/xml2js@0.4.14':
+    dependencies:
+      '@types/node': 20.17.24
 
   '@typescript-eslint/eslint-plugin@8.27.0(@typescript-eslint/parser@8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:
@@ -4159,6 +4183,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  sax@1.4.1: {}
+
   scheduler@0.25.0: {}
 
   semver@6.3.1: {}
@@ -4467,6 +4493,13 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.4.1
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/utils/formatDistance.ts
+++ b/utils/formatDistance.ts
@@ -1,0 +1,8 @@
+export function formatDistance(meters: number) {
+  if (meters < 1000) {
+    return `${meters}m`;
+  } else {
+    const kilometers = meters / 1000;
+    return `${Number(kilometers.toFixed(1))}km`;
+  }
+}


### PR DESCRIPTION
## Description of Changes

- Automatically triggered nearby place search on initial site load 
- Integrated a public medical API to enrich search results with detailed information
- Merged data from both APIs to provide more informative  results to users and enable advanced filtering
- Added a distance formatting utility for better UX
- Applied TanStack Query (useQuery) for efficient data fetching and caching
- Updated main page UI components to display fetched data
- Implemented geolocation-based initial data fetching when the page loads