### PR TITLE
feat: Implement address search modal with Kakao Local API and current location support

### DIFF
--- a/app/(pages)/(main)/_ui/AddressSearchModal.tsx
+++ b/app/(pages)/(main)/_ui/AddressSearchModal.tsx
@@ -14,11 +14,13 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { MapPin, Search } from "lucide-react";
 import { useLocationByAddress } from "@/lib/queries/useLocationByAddress";
+import { useGeoLocationStore } from "@/stores/useGeoLocation";
 
 export default function AddressSearchModal({}) {
   const [isOpen, setIsOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const [query, setQuery] = useState("");
+  const { setGeoLocation } = useGeoLocationStore();
 
   // 무한 스크롤 로직
   const lastSimilarAddressRef = useRef<HTMLButtonElement | null>(null);
@@ -58,6 +60,11 @@ export default function AddressSearchModal({}) {
     if (isKeyboardEvent && e.key !== "Enter") return;
 
     setQuery(searchValue);
+  };
+
+  const handleAddressSelected = (x: string, y: string) => {
+    setGeoLocation({ lat: Number(x), lng: Number(y) });
+    setIsOpen(false);
   };
 
   return (
@@ -122,7 +129,9 @@ export default function AddressSearchModal({}) {
                       similarAddress.y
                     }
                     ref={idx === arr.length - 1 ? lastSimilarAddressRef : null}
-                    onClick={() => setIsOpen(false)}
+                    onClick={() =>
+                      handleAddressSelected(similarAddress.y, similarAddress.x)
+                    }
                   >
                     {similarAddress.address_name}
                   </AddressSelectButton>

--- a/app/(pages)/(main)/_ui/AddressSearchModal.tsx
+++ b/app/(pages)/(main)/_ui/AddressSearchModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import {
   Dialog,
@@ -51,6 +51,15 @@ export default function AddressSearchModal({}) {
     // isFetchingNextPage가 바뀔때 마다 observer를 바꿈
   }, [hasNextPage, isFetchingNextPage]);
 
+  const handleSubmitSearchInput = (
+    e: React.MouseEvent | React.KeyboardEvent,
+  ) => {
+    const isKeyboardEvent = "key" in e;
+    if (isKeyboardEvent && e.key !== "Enter") return;
+
+    setQuery(searchValue);
+  };
+
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
@@ -80,13 +89,14 @@ export default function AddressSearchModal({}) {
                 placeholder="도로명 주소 또는 지번을 입력하세요"
                 value={searchValue}
                 onChange={(e) => setSearchValue(e.target.value)}
+                onKeyDown={handleSubmitSearchInput}
                 className="pl-8"
               />
             </div>
             <Button
               variant="default"
               className="cursor-pointer"
-              onClick={() => setQuery(searchValue)}
+              onClick={handleSubmitSearchInput}
             >
               <Search className="mr-1" size={16} />
               검색
@@ -105,18 +115,18 @@ export default function AddressSearchModal({}) {
               {pages
                 .flatMap((page) => page.documents)
                 .map((similarAddress, idx, arr) => (
-                                <AddressSelectButton
-key={
+                  <AddressSelectButton
+                    key={
                       similarAddress.address_name +
                       similarAddress.x +
                       similarAddress.y
                     }
                     ref={idx === arr.length - 1 ? lastSimilarAddressRef : null}
-onClick={() => setIsOpen(false)}
->
-                  {similarAddress.addr}
-                </AddressSelectButton>
-              ))}
+                    onClick={() => setIsOpen(false)}
+                  >
+                    {similarAddress.address_name}
+                  </AddressSelectButton>
+                ))}
             </ul>
           )}
         </div>

--- a/app/(pages)/(main)/_ui/AddressSearchModal.tsx
+++ b/app/(pages)/(main)/_ui/AddressSearchModal.tsx
@@ -15,12 +15,13 @@ import { Button } from "@/components/ui/button";
 import { MapPin, Search } from "lucide-react";
 import { useLocationByAddress } from "@/lib/queries/useLocationByAddress";
 import { useGeoLocationStore } from "@/stores/useGeoLocation";
+import { cn } from "@/lib/utils";
 
 export default function AddressSearchModal({}) {
   const [isOpen, setIsOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const [query, setQuery] = useState("");
-  const { setGeoLocation } = useGeoLocationStore();
+  const { geoLocation, setGeoLocation } = useGeoLocationStore();
 
   // 무한 스크롤 로직
   const lastSimilarAddressRef = useRef<HTMLButtonElement | null>(null);
@@ -70,7 +71,13 @@ export default function AddressSearchModal({}) {
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
-        <Button variant="secondary" className="flex-1 hover:cursor-pointer">
+        <Button
+          variant="secondary"
+          className={cn(
+            "flex-1 hover:cursor-pointer",
+            geoLocation && "border border-emerald-600 text-emerald-600",
+          )}
+        >
           <MapPin className="mr-1" size={16} />내 주변 찾기
         </Button>
       </DialogTrigger>

--- a/app/(pages)/(main)/_ui/AddressSearchModal.tsx
+++ b/app/(pages)/(main)/_ui/AddressSearchModal.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { MapPin, Search } from "lucide-react";
+
+export default function AddressSearchModal({}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState("");
+  const [query, setQuery] = useState("");
+  const similarAddresses: string[] | null = [];
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button variant="secondary" className="flex-1 hover:cursor-pointer">
+          <MapPin className="mr-1" size={16} />내 주변 찾기
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>내 주소 검색</DialogTitle>
+          <DialogDescription asChild>
+            <VisuallyHidden>
+              도로명 주소 또는 지번을 검색하고 내 주소를 선택하세요.
+            </VisuallyHidden>
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* 검색 인풋 + 버튼 */}
+        <div className="border-b pb-4">
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <Search
+                className="absolute top-1/2 left-2 -translate-y-1/2 text-gray-400"
+                size={16}
+              />
+              <Input
+                placeholder="도로명 주소 또는 지번을 입력하세요"
+                value={searchValue}
+                onChange={(e) => setSearchValue(e.target.value)}
+                className="pl-8"
+              />
+            </div>
+            <Button
+              variant="default"
+              className="cursor-pointer"
+              onClick={() => setQuery(searchValue)}
+            >
+              <Search className="mr-1" size={16} />
+              검색
+            </Button>
+          </div>
+        </div>
+
+        {/* 유사한 주소 리스트 */}
+        <div className="max-h-40 space-y-2 overflow-y-auto">
+          {similarAddresses == null ? (
+            <SearchPlaceholder />
+          ) : similarAddresses.length === 0 ? (
+            <NoSearchResult />
+          ) : (
+            <ul>
+              {similarAddresses.map((addr, idx) => (
+                // key = idx는 임시
+                <AddressSelectButton key={idx} onClick={() => setIsOpen(false)}>
+                  {addr}
+                </AddressSelectButton>
+              ))}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SearchPlaceholder() {
+  return (
+    <div className="text-muted-foreground py-4 text-center text-sm">
+      도로명 주소를 입력해주세요.
+      <br />
+      예) 백범로 10길 8, 세종대로 172
+    </div>
+  );
+}
+
+function NoSearchResult() {
+  return (
+    <div className="text-muted-foreground py-4 text-center text-sm">
+      검색 결과가 없습니다.
+    </div>
+  );
+}
+
+type AddressSelectButtonProps = Omit<
+  React.ComponentProps<"button">,
+  "className"
+>;
+
+function AddressSelectButton({ children, ...props }: AddressSelectButtonProps) {
+  return (
+    <li>
+      <button
+        {...props}
+        className="border-muted w-full border-b px-2 py-3 text-left text-sm transition hover:cursor-pointer hover:bg-emerald-50"
+      >
+        {children}
+      </button>
+    </li>
+  );
+}

--- a/app/(pages)/(main)/_ui/KakaoMap.tsx
+++ b/app/(pages)/(main)/_ui/KakaoMap.tsx
@@ -11,6 +11,7 @@ import {
   PlaceWithDetails,
 } from "@/lib/api/getPlacesByLocation";
 import { useMainPageStore } from "@/stores/useMainPageStore";
+import { useGeoLocationStore } from "@/stores/useGeoLocation";
 
 const MARKER_OPTIONS = [
   { id: "hospital", label: "병원" },
@@ -29,6 +30,7 @@ export default function KakaoMap({
   ...props
 }: KakaoMapProps) {
   const { activeTab } = useMainPageStore();
+  const { geoLocation } = useGeoLocationStore();
   const [isLoading, isError] = useKakaoLoader({
     appkey: process.env.NEXT_PUBLIC_KAKAO_JS_API_KEY!,
   });
@@ -42,8 +44,8 @@ export default function KakaoMap({
       {/* 카카오 지도 */}
       <Map
         center={{
-          lat: DEFAULT_GEOLOCATION.latitude,
-          lng: DEFAULT_GEOLOCATION.longitude,
+          lat: geoLocation?.lat || DEFAULT_GEOLOCATION.latitude,
+          lng: geoLocation?.lng || DEFAULT_GEOLOCATION.longitude,
         }}
         className="h-full w-full"
       >

--- a/app/(pages)/(main)/_ui/NearbyFilter.tsx
+++ b/app/(pages)/(main)/_ui/NearbyFilter.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import { useMainPageStore } from "@/stores/useMainPageStore";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
-import { MapPin, Filter, Moon, Music, Gift, BookOpen } from "lucide-react";
+import { Filter, Moon, Music, Gift, BookOpen } from "lucide-react";
+import AddressSearchModal from "./AddressSearchModal";
 
 export default function NearbyFilter() {
   const { filterGroups, setFilterGroups } = useMainPageStore();
@@ -12,9 +13,7 @@ export default function NearbyFilter() {
     <div className="space-y-4 border-b p-4">
       {/* 내 위치 기준 버튼 + 필터 토글 버튼 */}
       <div className="flex w-full gap-2">
-        <Button variant="secondary" className="flex-1 hover:cursor-pointer">
-          <MapPin className="mr-1" size={16} />내 주변 찾기
-        </Button>
+        <AddressSearchModal />
         <Button
           variant="outline"
           size="sm"

--- a/app/(pages)/(main)/page.tsx
+++ b/app/(pages)/(main)/page.tsx
@@ -10,16 +10,18 @@ import NearbyFilter from "./_ui/NearbyFilter";
 import HospitalPharmacyTabs from "./_ui/HospitalPharmacyTabs";
 import { usePlacesByLocation } from "@/lib/queries/usePlaceQueries";
 import { DEFAULT_GEOLOCATION } from "@/constants/defaultGeolocation";
+import { useGeoLocationStore } from "@/stores/useGeoLocation";
 
 export default function MainPage() {
   const { filterGroups } = useMainPageStore();
   const topButtonTriggerRef = useRef<HTMLDivElement | null>(null);
+  const { geoLocation } = useGeoLocationStore();
 
-  const [geoLocation, setGeoLocation] = useCurrentLocation();
+  useCurrentLocation();
 
   const { data: hospitals } = usePlacesByLocation(
-    geoLocation?.latitude || DEFAULT_GEOLOCATION.latitude,
-    geoLocation?.longitude || DEFAULT_GEOLOCATION.longitude,
+    geoLocation?.lat || DEFAULT_GEOLOCATION.latitude,
+    geoLocation?.lng || DEFAULT_GEOLOCATION.longitude,
     filterGroups.distance * 1000,
     1,
     "hospital",
@@ -29,8 +31,8 @@ export default function MainPage() {
   );
 
   const { data: pharmacies } = usePlacesByLocation(
-    geoLocation?.latitude || DEFAULT_GEOLOCATION.latitude,
-    geoLocation?.longitude || DEFAULT_GEOLOCATION.longitude,
+    geoLocation?.lat || DEFAULT_GEOLOCATION.latitude,
+    geoLocation?.lng || DEFAULT_GEOLOCATION.longitude,
     filterGroups.distance * 1000,
     1,
     "pharmacy",

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:cursor-pointer hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+          <XIcon />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/hooks/useCurrentLocation.ts
+++ b/hooks/useCurrentLocation.ts
@@ -1,12 +1,8 @@
-import React, { useState, useEffect } from "react";
+import { useGeoLocationStore } from "@/stores/useGeoLocation";
+import { useEffect } from "react";
 
-export default function useCurrentLocation(): [
-  GeolocationCoordinates | null,
-  React.Dispatch<React.SetStateAction<GeolocationCoordinates | null>>,
-] {
-  const [geoLocation, setGeoLocation] = useState<GeolocationCoordinates | null>(
-    null,
-  );
+export default function useCurrentLocation() {
+  const { geoLocation, setGeoLocation } = useGeoLocationStore();
 
   useEffect(() => {
     if (!navigator.geolocation) {
@@ -18,7 +14,8 @@ export default function useCurrentLocation(): [
       (success) => {
         console.log("사용자가 위치 정보를 허용했습니다.");
         if (success.coords.accuracy < 100) {
-          setGeoLocation(success.coords);
+          const { latitude, longitude } = success.coords;
+          setGeoLocation({ lat: latitude, lng: longitude });
         } else {
           console.log("위치 정보가 정확하지 않습니다 직접 입력 해주세요.");
         }
@@ -32,6 +29,4 @@ export default function useCurrentLocation(): [
       },
     );
   }, []);
-
-  return [geoLocation, setGeoLocation];
 }

--- a/lib/api/kakaoLocal.ts
+++ b/lib/api/kakaoLocal.ts
@@ -36,3 +36,26 @@ export const getPlaceByCategory = async (
     );
   }
 };
+
+export const getLocationByAddress = async (search: string, page: number) => {
+  const query = `query=${search}`;
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_KAKAO_LOCAL_BASE_URL}/search/address.json?${query}&page=${page}`,
+      {
+        headers: {
+          Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}`,
+        },
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error(`Kakao API Error ${res.status}: ${res.text()}`);
+    }
+
+    const data = await res.json();
+    return data;
+  } catch (error) {
+    throw new Error(`주소 검색하기 실패: ${(error as Error).message}`);
+  }
+};

--- a/lib/api/kakaoLocal.type.ts
+++ b/lib/api/kakaoLocal.type.ts
@@ -1,0 +1,48 @@
+export interface Address {
+  address_name: string;
+  region_1depth_name: string;
+  region_2depth_name: string;
+  region_3depth_name: string;
+  region_3depth_h_name?: string;
+  mountain_yn: "Y" | "N";
+  main_address_no: string;
+  sub_address_no: string;
+}
+
+export interface RoadAddress {
+  address_name: string;
+  region_1depth_name: string;
+  region_2depth_name: string;
+  region_3depth_name: string;
+  road_name: string;
+  underground_yn: "Y" | "N";
+  main_building_no: string;
+  sub_building_no: string;
+  building_name: string;
+  zone_no: string;
+}
+
+export interface LocationSearchResultByAddress {
+  address_name: string;
+  address_type: string;
+  x: string;
+  y: string;
+  address: Address | null;
+  road_address: RoadAddress | null;
+}
+
+export interface Meta {
+  is_end: boolean;
+  pageable_count: number;
+  total_count: number;
+  same_name?: {
+    region: string[];
+    keyword: string;
+    selected_region: string;
+  } | null;
+}
+
+export interface LocationByAddressResponse {
+  documents: LocationSearchResultByAddress[];
+  meta: Meta;
+}

--- a/lib/queries/queryKeys.ts
+++ b/lib/queries/queryKeys.ts
@@ -8,4 +8,7 @@ export const QUERY_KEYS = {
       category: string,
     ) => ["place", category, { lat, lng, radius, page }],
   },
+  location: {
+    byAddress: (address: string) => ["location", "byAddress", address],
+  },
 };

--- a/lib/queries/useLocationByAddress.ts
+++ b/lib/queries/useLocationByAddress.ts
@@ -1,0 +1,17 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { getLocationByAddress } from "../api/kakaoLocal";
+import { LocationByAddressResponse } from "../api/kakaoLocal.type";
+import { QUERY_KEYS } from "./queryKeys";
+
+export const useLocationByAddress = (address: string) => {
+  return useInfiniteQuery<LocationByAddressResponse>({
+    queryKey: QUERY_KEYS.location.byAddress(address),
+    queryFn: ({ pageParam }) =>
+      getLocationByAddress(address, pageParam as number),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      return lastPage.meta.is_end ? undefined : allPages.length + 1;
+    },
+    enabled: !!address,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-radio-group": "^1.2.3",
     "@radix-ui/react-slider": "^1.2.3",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.3",
+    "@radix-ui/react-visually-hidden": "^1.1.2",
     "@tanstack/react-query": "^5.69.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.6
+        version: 1.1.6(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.6
         version: 2.1.6(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -26,6 +29,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-visually-hidden':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/react-query':
         specifier: ^5.69.0
         version: 5.69.0(react@19.0.0)
@@ -426,6 +432,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.6':
+    resolution: {integrity: sha512-/IVhJV5AceX620DUJ4uYVMymzsipdKBzo3edo+omeskCKGm9FRHM0ebIdbPnlQVJqyuHbuBltQUOG2mOTq2IYw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.0':
     resolution: {integrity: sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==}
     peerDependencies:
@@ -692,6 +711,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.1.2':
+    resolution: {integrity: sha512-1SzA4ns2M1aRlvxErqhLHsBHoS5eI5UUcI2awAMgGUp4LoaoWOKYmvqDY2s/tltuPkh3Yk77YF/r3IRj+Amx4Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/rect@1.1.0':
@@ -2522,6 +2554,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.12
 
+  '@radix-ui/react-dialog@1.1.6(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-dismissable-layer': 1.1.5(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-focus-scope': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-portal': 1.1.4(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.12)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.12)(react@19.0.0)
+      aria-hidden: 1.2.4
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-remove-scroll: 2.6.3(@types/react@19.0.12)(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.12
+      '@types/react-dom': 19.0.4(@types/react@19.0.12)
+
   '@radix-ui/react-direction@1.1.0(@types/react@19.0.12)(react@19.0.0)':
     dependencies:
       react: 19.0.0
@@ -2784,6 +2838,15 @@ snapshots:
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.12
+
+  '@radix-ui/react-visually-hidden@1.1.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.12
+      '@types/react-dom': 19.0.4(@types/react@19.0.12)
 
   '@radix-ui/rect@1.1.0': {}
 

--- a/stores/useGeoLocation.ts
+++ b/stores/useGeoLocation.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface GeoLocationState {
+  geoLocation: { lat: number; lng: number } | null;
+  setGeoLocation: (geoLocation: { lat: number; lng: number }) => void;
+}
+
+export const useGeoLocationStore = create<GeoLocationState>((set) => ({
+  geoLocation: null,
+  setGeoLocation: (location) => set(() => ({ geoLocation: location })),
+}));


### PR DESCRIPTION
## Description of Changes

- Installed shadcn/ui Dialog and @radix-ui/react-visually-hidden for accessibility
- Added AddressSearchModal component for address-based location search
- Integrated Kakao Local API to search locations by address
- Applied useInfiniteQuery for infinite scroll of address results
- Abstracted search input logic into handleSubmitSearchInput function
- Created useGeoLocationStore using zustand for global location state
- Synced useCurrentLocation hook with useGeoLocationStore to initialize location on first load
- Updated KakaoMap to center based on selected address coordinates
- Applied conditional highlight (emerald-600) to the "Find My Location" button when geoLocation is set