### PR TITLE
feat(mainpage): Display keyword search results in tab UI

### DIFF
--- a/app/(pages)/(main)/_ui/AddressSearchModal.tsx
+++ b/app/(pages)/(main)/_ui/AddressSearchModal.tsx
@@ -61,6 +61,7 @@ export default function AddressSearchModal({}) {
     if (isKeyboardEvent && e.key !== "Enter") return;
 
     setQuery(searchValue);
+    setSearchValue("");
   };
 
   const handleAddressSelected = (x: string, y: string) => {

--- a/app/(pages)/(main)/_ui/AddressSearchModal.tsx
+++ b/app/(pages)/(main)/_ui/AddressSearchModal.tsx
@@ -16,12 +16,14 @@ import { MapPin, Search } from "lucide-react";
 import { useLocationByAddress } from "@/lib/queries/useLocationByAddress";
 import { useGeoLocationStore } from "@/stores/useGeoLocation";
 import { cn } from "@/lib/utils";
+import { useMainPageStore } from "@/stores/useMainPageStore";
 
 export default function AddressSearchModal({}) {
   const [isOpen, setIsOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const [query, setQuery] = useState("");
-  const { geoLocation, setGeoLocation } = useGeoLocationStore();
+  const { isSearchMode, setIsSearchMode } = useMainPageStore();
+  const { setGeoLocation } = useGeoLocationStore();
 
   // 무한 스크롤 로직
   const lastSimilarAddressRef = useRef<HTMLButtonElement | null>(null);
@@ -66,6 +68,7 @@ export default function AddressSearchModal({}) {
 
   const handleAddressSelected = (x: string, y: string) => {
     setGeoLocation({ lat: Number(x), lng: Number(y) });
+    setIsSearchMode(false);
     setIsOpen(false);
   };
 
@@ -76,7 +79,7 @@ export default function AddressSearchModal({}) {
           variant="secondary"
           className={cn(
             "flex-1 hover:cursor-pointer",
-            geoLocation && "border border-emerald-600 text-emerald-600",
+            !isSearchMode && "border border-emerald-600 text-emerald-600",
           )}
         >
           <MapPin className="mr-1" size={16} />내 주변 찾기

--- a/app/(pages)/(main)/_ui/HospitalPharmacyTabs.tsx
+++ b/app/(pages)/(main)/_ui/HospitalPharmacyTabs.tsx
@@ -16,6 +16,7 @@ interface HospitalPharmacyTabsProps {
   infiniteValues: {
     hospital: InfiniteQueryValues;
     pharmacy: InfiniteQueryValues;
+    search: InfiniteQueryValues;
   };
 }
 
@@ -24,7 +25,7 @@ export default function HospitalPharmacyTabs({
   pharmacies,
   infiniteValues,
 }: HospitalPharmacyTabsProps) {
-  const { activeTab, setActiveTab } = useMainPageStore();
+  const { activeTab, setActiveTab, isSearchMode } = useMainPageStore();
 
   return (
     <div className="flex-1 overflow-y-auto p-4">
@@ -62,7 +63,9 @@ export default function HospitalPharmacyTabs({
           <TabContentList
             type="hospital"
             data={hospitals}
-            infiniteQuery={infiniteValues.hospital}
+            infiniteQuery={
+              isSearchMode ? infiniteValues.search : infiniteValues.hospital
+            }
           />
         </TabsContent>
 
@@ -70,7 +73,9 @@ export default function HospitalPharmacyTabs({
           <TabContentList
             type="pharmacy"
             data={pharmacies}
-            infiniteQuery={infiniteValues.pharmacy}
+            infiniteQuery={
+              isSearchMode ? infiniteValues.search : infiniteValues.pharmacy
+            }
           />
         </TabsContent>
       </Tabs>

--- a/app/(pages)/(main)/_ui/KakaoMap.tsx
+++ b/app/(pages)/(main)/_ui/KakaoMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -34,19 +34,11 @@ export default function KakaoMap({
   ref,
   ...props
 }: KakaoMapProps) {
-  const mapRef = useRef<kakao.maps.Map>(null);
   const { map, activeTab } = useMainPageStore();
   const { geoLocation } = useGeoLocationStore();
   const [isLoading, isError] = useKakaoLoader({
     appkey: process.env.NEXT_PUBLIC_KAKAO_JS_API_KEY!,
   });
-
-  // mapRef가 생성 되면 최초 한번 zustand에 등록
-  useEffect(() => {
-    if (mapRef.current) {
-      map.setRef(mapRef.current);
-    }
-  }, [mapRef.current]);
 
   // geoLocation값이 바뀌면 지도의 중앙을 업데이트
   useEffect(() => {
@@ -58,6 +50,17 @@ export default function KakaoMap({
     }
   }, [geoLocation]);
 
+  // Map이 마운트 되면서 ref가 할당될 때 실행되는 콜백 ref
+  const setMapRef = useCallback(
+    (element: kakao.maps.Map | null) => {
+      // map.ref가 null이 아닐 때 까지만 실행
+      if (element && element !== map.ref) {
+        map.setRef(element);
+      }
+    },
+    [map.ref], // if 문에서 비교를 위한 deps
+  );
+
   return (
     <div
       className="relative h-[50vh] w-full md:h-full md:w-2/3"
@@ -65,7 +68,7 @@ export default function KakaoMap({
       {...props}
     >
       {/* 카카오 지도 */}
-      <Map center={map.center} ref={mapRef} className="h-full w-full">
+      <Map center={map.center} ref={setMapRef} className="h-full w-full">
         {geoLocation && (
           <MapMarker
             position={{ lat: geoLocation.lat, lng: geoLocation.lng }}

--- a/app/(pages)/(main)/_ui/KakaoMap.tsx
+++ b/app/(pages)/(main)/_ui/KakaoMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useEffect, useCallback } from "react";
+import React, { useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -60,6 +60,21 @@ export default function KakaoMap({
     },
     [map.ref], // if 문에서 비교를 위한 deps
   );
+
+  if (isError) return <div>카카오맵 API 에러</div>;
+
+  if (isLoading)
+    return (
+      <div
+        className="relative h-[50vh] w-full bg-gray-100 md:h-full md:w-2/3"
+        ref={ref}
+        {...props}
+      >
+        <div className="flex h-full w-full items-center justify-center">
+          Loading...
+        </div>
+      </div>
+    );
 
   return (
     <div

--- a/app/(pages)/(main)/_ui/SearchBar.tsx
+++ b/app/(pages)/(main)/_ui/SearchBar.tsx
@@ -17,12 +17,14 @@ export default function SearchBar() {
     if (isKeyboardEvent && e.key !== "Enter") return;
 
     setIsSearchMode(true);
+
     // KakaoMap ref를 통해 현재 보여지는 지도의 중앙을 현재 위치 정보로 설정하고 검색
     if (map.ref) {
       const center = map.ref.getCenter();
       setGeoLocation({ lat: center.getLat(), lng: center.getLng() });
     }
-    setFilterGroups("query", searchValue);
+    setFilterGroups("query", searchValue.trim());
+
     setSearchValue("");
   };
 

--- a/app/(pages)/(main)/_ui/SearchBar.tsx
+++ b/app/(pages)/(main)/_ui/SearchBar.tsx
@@ -22,6 +22,7 @@ export default function SearchBar() {
       setGeoLocation({ lat: center.getLat(), lng: center.getLng() });
     }
     setFilterGroups("query", searchValue);
+    setSearchValue("");
   };
 
   return (

--- a/app/(pages)/(main)/_ui/SearchBar.tsx
+++ b/app/(pages)/(main)/_ui/SearchBar.tsx
@@ -7,7 +7,7 @@ import { useGeoLocationStore } from "@/stores/useGeoLocation";
 
 export default function SearchBar() {
   const [searchValue, setSearchValue] = useState("");
-  const { setFilterGroups, map } = useMainPageStore();
+  const { setFilterGroups, map, setIsSearchMode } = useMainPageStore();
   const { setGeoLocation } = useGeoLocationStore();
 
   const handleSubmitSearchInput = (
@@ -16,6 +16,7 @@ export default function SearchBar() {
     const isKeyboardEvent = "key" in e;
     if (isKeyboardEvent && e.key !== "Enter") return;
 
+    setIsSearchMode(true);
     // KakaoMap ref를 통해 현재 보여지는 지도의 중앙을 현재 위치 정보로 설정하고 검색
     if (map.ref) {
       const center = map.ref.getCenter();

--- a/app/(pages)/(main)/page.tsx
+++ b/app/(pages)/(main)/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 import useCurrentLocation from "@/hooks/useCurrentLocation";
 import { useMainPageStore } from "@/stores/useMainPageStore";
 import ScrollToTopButton from "@/app/_ui/shared/ScrollToTopButton";
@@ -13,11 +13,16 @@ import { useGeoLocationStore } from "@/stores/useGeoLocation";
 import { Meta } from "@/lib/api/kakaoLocal.type";
 
 export default function MainPage() {
-  const { filterGroups } = useMainPageStore();
+  const { filterGroups, isSearchMode, setIsSearchMode } = useMainPageStore();
   const topButtonTriggerRef = useRef<HTMLDivElement | null>(null);
-  const { geoLocation } = useGeoLocationStore();
+  const { geoLocation, isAutoLoaded } = useCurrentLocation();
 
-  useCurrentLocation();
+  // 첫 자동 위치 감지 성공 시 한 번만 검색 모드를 꺼줌
+  useEffect(() => {
+    if (isAutoLoaded) {
+      setIsSearchMode(false);
+    }
+  }, [isAutoLoaded]);
 
   const {
     data: infiniteHospitals,

--- a/app/(pages)/(main)/page.tsx
+++ b/app/(pages)/(main)/page.tsx
@@ -63,7 +63,7 @@ export default function MainPage() {
     geoLocation?.lng,
     filterGroups.distance * 1000,
     filterGroups.query,
-    isSearchMode && !!filterGroups.query,
+    isSearchMode && !!filterGroups.query && !!geoLocation,
   );
 
   let hospitals, pharmacies;

--- a/app/(pages)/(main)/page.tsx
+++ b/app/(pages)/(main)/page.tsx
@@ -124,7 +124,7 @@ export default function MainPage() {
     } else if (firstCategory === CATEGORY_CODE.pharmacy) {
       setActiveTab("pharmacy");
     }
-  }, [infiniteSearchResults]);
+  }, [isSearchMode, infiniteSearchResults]);
 
   return (
     <div className="flex flex-col md:h-[calc(100vh-5rem)] md:flex-row">

--- a/hooks/useCurrentLocation.ts
+++ b/hooks/useCurrentLocation.ts
@@ -1,8 +1,9 @@
 import { useGeoLocationStore } from "@/stores/useGeoLocation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export default function useCurrentLocation() {
   const { geoLocation, setGeoLocation } = useGeoLocationStore();
+  const [isAutoLoaded, setIsAutoLoaded] = useState(false);
 
   useEffect(() => {
     if (!navigator.geolocation) {
@@ -16,6 +17,7 @@ export default function useCurrentLocation() {
         if (success.coords.accuracy < 100) {
           const { latitude, longitude } = success.coords;
           setGeoLocation({ lat: latitude, lng: longitude });
+          setIsAutoLoaded(true);
         } else {
           console.log("위치 정보가 정확하지 않습니다 직접 입력 해주세요.");
         }
@@ -29,4 +31,6 @@ export default function useCurrentLocation() {
       },
     );
   }, []);
+
+  return { geoLocation, setGeoLocation, isAutoLoaded };
 }

--- a/lib/queries/queryKeys.ts
+++ b/lib/queries/queryKeys.ts
@@ -6,13 +6,11 @@ export const QUERY_KEYS = {
       radius: number,
       category: string,
     ) => ["place", category, { lat, lng, radius }],
-    byKeyword: (
-      lat: number,
-      lng: number,
-      radius: number,
-      page: number,
-      keyword: string,
-    ) => ["keyword", keyword, { lat, lng, radius, page }],
+    byKeyword: (lat: number, lng: number, radius: number, keyword: string) => [
+      "keyword",
+      keyword,
+      { lat, lng, radius },
+    ],
   },
   location: {
     byAddress: (address: string) => ["location", "byAddress", address],

--- a/lib/queries/usePlaceQueries.ts
+++ b/lib/queries/usePlaceQueries.ts
@@ -18,6 +18,7 @@ export const usePlacesByLocation = (
   lng: number | undefined,
   radius: number = 1000,
   category: "hospital" | "pharmacy" = "hospital",
+  enabled: boolean,
 ) => {
   return useInfiniteQuery<PlacesByLocationResponse>({
     queryKey: QUERY_KEYS.places.byLocation(lat!, lng!, radius, category),
@@ -27,7 +28,7 @@ export const usePlacesByLocation = (
     getNextPageParam: (lastPage, allPages) => {
       return lastPage.meta.is_end ? undefined : allPages.length + 1;
     },
-    enabled: !!(lat && lng),
+    enabled,
   });
 };
 

--- a/lib/queries/usePlaceQueries.ts
+++ b/lib/queries/usePlaceQueries.ts
@@ -1,8 +1,4 @@
-import {
-  useQuery,
-  UseQueryOptions,
-  useInfiniteQuery,
-} from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { QUERY_KEYS } from "./queryKeys";
 import {
   getPlacesByLocation,
@@ -33,19 +29,20 @@ export const usePlacesByLocation = (
 };
 
 export const usePlacesByKeyword = (
-  lat: number,
-  lng: number,
+  lat: number | undefined,
+  lng: number | undefined,
   radius: number = 1000,
-  page: number = 1,
   keyword: string = "",
-  options?: Omit<
-    UseQueryOptions<PlacesByKeywordResponse>,
-    "queryKey" | "queryFn"
-  >,
+  enabled: boolean,
 ) => {
-  return useQuery<PlacesByKeywordResponse>({
-    queryKey: QUERY_KEYS.places.byKeyword(lat, lng, radius, page, keyword),
-    queryFn: () => getPlacesByKeyword(lat, lng, radius, page, keyword),
-    ...options,
+  return useInfiniteQuery<PlacesByKeywordResponse>({
+    queryKey: QUERY_KEYS.places.byKeyword(lat!, lng!, radius, keyword),
+    queryFn: ({ pageParam }) =>
+      getPlacesByKeyword(lat!, lng!, radius, pageParam as number, keyword),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      return lastPage.meta.is_end ? undefined : allPages.length + 1;
+    },
+    enabled,
   });
 };

--- a/stores/useMainPageStore.ts
+++ b/stores/useMainPageStore.ts
@@ -29,6 +29,8 @@ interface MainPageState {
   map: MapControlState;
   activeTab: "hospital" | "pharmacy";
   setActiveTab: (tab: "hospital" | "pharmacy") => void;
+  isSearchMode: boolean;
+  setIsSearchMode: (isSearchMode: boolean) => void;
 }
 
 export const useMainPageStore = create<MainPageState>((set) => ({
@@ -81,4 +83,6 @@ export const useMainPageStore = create<MainPageState>((set) => ({
   },
   activeTab: "hospital",
   setActiveTab: (tab) => set({ activeTab: tab }),
+  isSearchMode: true,
+  setIsSearchMode: (isSearchMode) => set({ isSearchMode }),
 }));


### PR DESCRIPTION
## Description of Changes

- Added an `enabled` flag in `usePlacesByLocation` to control when the query should execute.
- Implemented `usePlacesByKeyword` query to enable keyword-based place search on the main page.
- Reset the keyword search input and address search input after a search is submitted to improve UX.
- Introduced a global `isSearchMode` state using Zustand to distinguish between location-based and keyword-based searches.
- Integrated the `isSearchMode` state into the main page logic to conditionally switch search modes.
- Applied `useInfiniteQuery` for handling paginated results in keyword search mode.
- Fixed an issue where `geoLocation` was `undefined` on the first search attempt.
- Added a tab-based UI to switch between different types of keyword search results.
- Fixed a linting error and added a loading UI for the map while data is being fetched.
