### PR TITLE
feat(detailpage): Add place info api request in server side

### DIFF
--- a/app/(pages)/(main)/_ui/HospitalPharmacyCard.tsx
+++ b/app/(pages)/(main)/_ui/HospitalPharmacyCard.tsx
@@ -7,6 +7,7 @@ import {
 import Link from "next/link";
 import { formatDistance } from "@/utils/formatDistance";
 import { PlaceWithDetails } from "@/lib/api/unifiedLocationApi.type";
+import { buildPlaceDetailQuery } from "@/utils/buildQueryString";
 
 interface HospitalPharmacyCardProps {
   place: PlaceWithDetails;
@@ -15,9 +16,11 @@ interface HospitalPharmacyCardProps {
 export default function HospitalPharmacyCard({
   place,
 }: HospitalPharmacyCardProps) {
+  const query = buildPlaceDetailQuery(place);
+
   return (
     <li>
-      <Link href={`/clinic/${place.id}`}>
+      <Link href={`/clinic/${place.id}?${query}`}>
         <Card className="relative py-3">
           <span className="text-muted-foreground absolute top-2 right-3 text-sm">
             {formatDistance(Number(place.distance)) || "? m"}

--- a/app/(pages)/clinic/[id]/_ui/PlaceBasicInfo.tsx
+++ b/app/(pages)/clinic/[id]/_ui/PlaceBasicInfo.tsx
@@ -10,8 +10,7 @@ export default function PlaceBasicInfo({ placeData }: PlaceBasicInfoProps) {
     { label: "분류", value: placeData.category_name },
     { label: "주소", value: placeData.road_address_name },
     { label: "전화번호", value: placeData.phone },
-    { label: "거리", value: `${placeData.distance}m` },
-    { label: "웹사이트", value: `${placeData.place_url}m` },
+    { label: "카카오맵", value: `${placeData.place_url}m` },
   ];
 
   return (
@@ -22,7 +21,7 @@ export default function PlaceBasicInfo({ placeData }: PlaceBasicInfoProps) {
       {infoList.map((item) => (
         <p key={item.label} className="text-sm text-gray-600">
           <span className="mr-1 font-medium text-gray-800">{item.label}:</span>
-          {item.label === "웹사이트" ? (
+          {item.label === "카카오맵" ? (
             <Link
               href={placeData.place_url}
               target="_blank"

--- a/app/(pages)/clinic/[id]/page.tsx
+++ b/app/(pages)/clinic/[id]/page.tsx
@@ -13,16 +13,16 @@ import {
 import { PlaceDocument } from "@/lib/api/kakaoLocal.type";
 import { PublicDataItem } from "@/lib/api/publicData.type";
 
-interface PlaceDetailPageProps {
-  params: { id: string };
-  searchParams: {
+type PlaceDetailPageProps = {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{
     x?: string;
     y?: string;
     name?: string;
     addr?: string;
     code?: string;
-  };
-}
+  }>;
+};
 
 export default async function PlaceDetailPage({
   params,

--- a/lib/api/kakaoLocal.ts
+++ b/lib/api/kakaoLocal.ts
@@ -1,4 +1,8 @@
 import { CATEGORY_CODE } from "@/constants/categoryCode";
+import {
+  PlacesByCategoryResponse,
+  PlacesByKeywordResponse,
+} from "./kakaoLocal.type";
 
 export const getPlaceByCategory = async (
   lat: number,
@@ -6,7 +10,7 @@ export const getPlaceByCategory = async (
   radius: number,
   page: number,
   category: "hospital" | "pharmacy",
-) => {
+): Promise<PlacesByCategoryResponse> => {
   const categoryCode = CATEGORY_CODE[category];
 
   const query = `category_group_code=${categoryCode}&x=${lng}&y=${lat}&radius=${radius}&size=10&page=${page}&sort=distance`;
@@ -26,7 +30,7 @@ export const getPlaceByCategory = async (
     }
 
     const data = await res.json();
-    return data;
+    return data as PlacesByCategoryResponse;
   } catch (error) {
     throw new Error(
       `${category === "hospital" ? "병원" : "약국"} 정보 불러오기 실패: ${(error as Error).message}`,
@@ -40,7 +44,7 @@ export const getPlaceByKeyword = async (
   radius: number,
   page: number,
   keyword: string,
-) => {
+): Promise<PlacesByKeywordResponse> => {
   const query = `query=${keyword}&x=${lng}&y=${lat}&radius=${radius}&size=10&page=${page}&sort=distance`;
 
   try {
@@ -59,7 +63,36 @@ export const getPlaceByKeyword = async (
 
     const data = await res.json();
 
-    return data;
+    return data as PlacesByKeywordResponse;
+  } catch (error) {
+    throw new Error(`키워드 검색하기 실패: ${(error as Error).message}`);
+  }
+};
+
+export const getPlaceByName = async (
+  name: string,
+  x: number,
+  y: number,
+): Promise<PlacesByKeywordResponse> => {
+  const query = `query=${name}&x=${x}&y=${y}&radius=1000&sort=distance`;
+
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_KAKAO_LOCAL_BASE_URL}/search/keyword.json?${query}`,
+      {
+        headers: {
+          Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}`,
+        },
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error(`Kakao API Error ${res.status}: ${res.text()}`);
+    }
+
+    const data = await res.json();
+
+    return data as PlacesByKeywordResponse;
   } catch (error) {
     throw new Error(`키워드 검색하기 실패: ${(error as Error).message}`);
   }

--- a/lib/api/kakaoLocal.type.ts
+++ b/lib/api/kakaoLocal.type.ts
@@ -31,8 +31,9 @@ export interface LocationSearchResultByAddress {
   road_address: RoadAddress | null;
 }
 
-export interface PlaceDocumentSummary {
+export interface PlaceDocument {
   road_address_name: string;
+  address_name: string;
   category_name: string;
   category_group_code: string;
   distance: string;
@@ -60,7 +61,12 @@ export interface LocationByAddressResponse {
   meta: Meta;
 }
 
+export interface PlacesByCategoryResponse {
+  documents: PlaceDocument[];
+  meta: Meta;
+}
+
 export interface PlacesByKeywordResponse {
-  documents: PlaceDocumentSummary[];
+  documents: PlaceDocument[];
   meta: Meta;
 }

--- a/lib/api/publicData.ts
+++ b/lib/api/publicData.ts
@@ -1,6 +1,11 @@
 import { parseStringPromise } from "xml2js";
+import { PublicDataResponse, PublicDataItem } from "./publicData.type";
 
-export const getHospitalDetailsByName = async (name: string, addr?: string) => {
+export const getHospitalDetailsByName = async (
+  name: string,
+  addr: string,
+  from: "server" | "client" = "client",
+): Promise<PublicDataResponse> => {
   // QN 파라미터에 공백 등이 포함될 수 있어 encodeURIComponent 적용
   let query = `serviceKey=${process.env.NEXT_PUBLIC_DATA_GO_KR_API_KEY}&QN=${encodeURIComponent(name)}`;
   if (addr) {
@@ -9,9 +14,16 @@ export const getHospitalDetailsByName = async (name: string, addr?: string) => {
     query += `&Q1=${splittedAddress[1]}`;
   }
 
-  const res = await fetch(
-    `/api/public-data/hospital/getHsptlMdcncListInfoInqire?${query}`,
-  );
+  let res;
+  if (from === "client") {
+    res = await fetch(
+      `/api/public-data/hospital/getHsptlMdcncListInfoInqire?${query}`,
+    );
+  } else {
+    res = await fetch(
+      `${process.env.NEXT_PUBLIC_DATA_HOSPITAL_BASE_URL}/getHsptlMdcncListInfoInqire?${query}`,
+    );
+  }
 
   if (!res.ok) {
     throw new Error(
@@ -25,10 +37,17 @@ export const getHospitalDetailsByName = async (name: string, addr?: string) => {
     trim: true,
   });
 
-  return jsonData.response?.body?.items?.item;
+  const item = jsonData.response?.body?.items?.item;
+
+  if (!item) return null;
+  return (Array.isArray(item) ? item[0] : item) as PublicDataItem;
 };
 
-export const getPharmacyDetailsByName = async (name: string, addr?: string) => {
+export const getPharmacyDetailsByName = async (
+  name: string,
+  addr: string,
+  from: "server" | "client" = "client",
+): Promise<PublicDataResponse> => {
   // QN 파라미터에 공백 등이 포함될 수 있어 encodeURIComponent 적용
   let query = `serviceKey=${process.env.NEXT_PUBLIC_DATA_GO_KR_API_KEY}&QN=${encodeURIComponent(name)}`;
   if (addr) {
@@ -37,9 +56,16 @@ export const getPharmacyDetailsByName = async (name: string, addr?: string) => {
     query += `&Q1=${splittedAddress[1]}`;
   }
 
-  const res = await fetch(
-    `/api/public-data/pharmacy/getParmacyListInfoInqire?${query}`,
-  );
+  let res;
+  if (from === "client") {
+    res = await fetch(
+      `/api/public-data/pharmacy/getParmacyListInfoInqire?${query}`,
+    );
+  } else {
+    res = await fetch(
+      `${process.env.NEXT_PUBLIC_DATA_PHARMACY_BASE_URL}/getParmacyListInfoInqire?${query}`,
+    );
+  }
 
   if (!res.ok) {
     throw new Error(
@@ -53,5 +79,8 @@ export const getPharmacyDetailsByName = async (name: string, addr?: string) => {
     trim: true,
   });
 
-  return jsonData.response?.body?.items?.item;
+  const item = jsonData.response?.body?.items?.item;
+
+  if (!item) return null;
+  return (Array.isArray(item) ? item[0] : item) as PublicDataItem;
 };

--- a/lib/api/publicData.type.ts
+++ b/lib/api/publicData.type.ts
@@ -1,0 +1,3 @@
+export type PublicDataItem = Record<string, string>;
+
+export type PublicDataResponse = PublicDataItem | null;

--- a/lib/api/unifiedLocationApi.ts
+++ b/lib/api/unifiedLocationApi.ts
@@ -3,7 +3,7 @@ import {
   getHospitalDetailsByName,
   getPharmacyDetailsByName,
 } from "./publicData";
-import { PlaceDocumentSummary } from "./kakaoLocal.type";
+import { PlaceDocument } from "./kakaoLocal.type";
 import {
   PlacesByLocationResponse,
   PlacesByKeywordResponse,
@@ -30,11 +30,9 @@ export const getPlacesByLocation = async (
     return { places: [], meta };
   }
 
-  const placesSummary: PlaceDocumentSummary[] = places.map(extractPlaceSummary);
-
   // 공공 데이터 API 요청 병렬 처리
   const placesWithDetails = await Promise.all(
-    placesSummary.map((place) =>
+    places.map((place) =>
       enrichPlaceWithDetails(place, place.category_group_code),
     ),
   );
@@ -66,11 +64,9 @@ export const getPlacesByKeyword = async (
     return { places: [], meta };
   }
 
-  const placesSummary: PlaceDocumentSummary[] = places.map(extractPlaceSummary);
-
   // 공공 데이터 API 요청 병렬 처리
   const placesWithDetails = await Promise.all(
-    placesSummary.map((place) =>
+    places.map((place) =>
       enrichPlaceWithDetails(place, place.category_group_code),
     ),
   );
@@ -82,10 +78,7 @@ export const getPlacesByKeyword = async (
   } as PlacesByKeywordResponse;
 };
 
-async function enrichPlaceWithDetails(
-  place: PlaceDocumentSummary,
-  category: string,
-) {
+async function enrichPlaceWithDetails(place: PlaceDocument, category: string) {
   const { place_name, road_address_name } = place;
   try {
     let details = null;
@@ -99,23 +92,4 @@ async function enrichPlaceWithDetails(
     console.error(`공공 데이터 요청 실패: ${place_name} ${error}`);
     return { ...place, details: null };
   }
-}
-
-// 받아온 place에서 필요한 값만 추출해서 요약하는 함수
-// place에 실제로 key, value가 더 있으나 사용하지 않기 때문에 타입 정의는 PlaceDocumentSummary로 함
-function extractPlaceSummary(
-  place: PlaceDocumentSummary,
-): PlaceDocumentSummary {
-  return {
-    road_address_name: place.road_address_name,
-    category_name: place.category_name,
-    category_group_code: place.category_group_code,
-    distance: place.distance,
-    id: place.id,
-    phone: place.phone,
-    place_name: place.place_name,
-    place_url: place.place_url,
-    x: place.x,
-    y: place.y,
-  };
 }

--- a/lib/api/unifiedLocationApi.type.ts
+++ b/lib/api/unifiedLocationApi.type.ts
@@ -1,7 +1,7 @@
-import { PlaceDocumentSummary, Meta } from "./kakaoLocal.type";
+import { PlaceDocument, Meta } from "./kakaoLocal.type";
 
 // 카카오 로컬 API 데이터 + 공공 데이터
-export interface PlaceWithDetails extends PlaceDocumentSummary {
+export interface PlaceWithDetails extends PlaceDocument {
   details: Record<string, string> | null; // 공공 데이터 response가 데이터마다 전부 달라서 Record로 처리
 }
 

--- a/utils/buildQueryString.ts
+++ b/utils/buildQueryString.ts
@@ -1,0 +1,29 @@
+import { PlaceWithDetails } from "@/lib/api/unifiedLocationApi.type";
+
+/**
+ * 주어진 장소 정보(`PlaceWithDetails`)를 기반으로
+ * `/clinic/[id]` 페이지에서 사용할 URL 쿼리 문자열을 생성합니다.
+ *
+ * - `place_name` → name
+ * - `road_address_name` → addr
+ * - `x` or `lng` → x
+ * - `y` or `lat` → y
+ *
+ * URLSearchParams를 사용하여 자동 인코딩되며,
+ * 결과는 `name=...&addr=...&x=...&y=...` 형태입니다.
+ *
+ * @param place - 쿼리로 만들 장소 정보 객체
+ * @returns 인코딩된 URL 쿼리 문자열
+ */
+export function buildPlaceDetailQuery(place: PlaceWithDetails) {
+  const { place_name, road_address_name, x, y } = place;
+
+  const query = new URLSearchParams();
+
+  query.set("name", place_name);
+  query.set("addr", road_address_name);
+  query.set("x", x);
+  query.set("y", y);
+
+  return query.toString();
+}


### PR DESCRIPTION
## Description of Changes

- main page
1. Updated Hospital and Pharmacy Card links with detail page query builder utils (`buildPlaceDetailQuery`)

- detail page
1. Fetched kakao & public data server-side in detail page

- apis
1. Renamed type `PlaceDocumentSummary` → `PlaceDocument`
2. Added type `PlacesByCategoryResponse`
3. Added public data api type
4. Refactored api functions with these types
